### PR TITLE
security: replace pickle with json for cookie storage

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ from selenium.common.exceptions import TimeoutException, ElementClickIntercepted
 from flask import Flask, render_template, request, jsonify, session, redirect, url_for, send_from_directory, flash
 import time
 import logging
-import pickle
+import json
 import os
 import shutil
 
@@ -93,7 +93,7 @@ def process_connections():
     
     try:
         driver = init_driver()
-        cookie_path = os.path.join('cookies', f"linkedin_cookies_{session['username']}.pkl")
+        cookie_path = os.path.join('cookies', f"linkedin_cookies_{session['username']}.json")
         
         if not os.path.exists(cookie_path):
             return jsonify({'success': False, 'message': 'No valid session found. Please login again.'})
@@ -118,8 +118,8 @@ def accept_connections(driver, cookie_path):
     try:
         # Load cookies
         driver.get('https://www.linkedin.com')
-        with open(cookie_path, 'rb') as file:
-            cookies = pickle.load(file)
+        with open(cookie_path, 'r') as file:
+            cookies = json.load(file)
             for cookie in cookies:
                 driver.add_cookie(cookie)
         
@@ -233,9 +233,9 @@ def submit_password():
         if not os.path.exists(cookie_dir):
             os.makedirs(cookie_dir)
         
-        cookie_path = os.path.join(cookie_dir, f"linkedin_cookies_{username}.pkl")
-        with open(cookie_path, 'wb') as file:
-            pickle.dump(driver.get_cookies(), file)
+        cookie_path = os.path.join(cookie_dir, f"linkedin_cookies_{username}.json")
+        with open(cookie_path, 'w') as file:
+            json.dump(driver.get_cookies(), file)
         
         return jsonify({'success': True, 'redirect': '/connections'})
 
@@ -285,9 +285,9 @@ def submit_otp():
         if not os.path.exists(cookie_dir):
             os.makedirs(cookie_dir)
             
-        cookie_path = os.path.join(cookie_dir, f"linkedin_cookies_{session['username']}.pkl")
-        with open(cookie_path, 'wb') as file:
-            pickle.dump(cookies, file)
+        cookie_path = os.path.join(cookie_dir, f"linkedin_cookies_{session['username']}.json")
+        with open(cookie_path, 'w') as file:
+            json.dump(cookies, file)
         
         return jsonify({'success': True, 'redirect': '/connections'})
 
@@ -308,7 +308,7 @@ def check_session():
         return jsonify({'valid': False})
         
     # Check if cookie file exists
-    cookie_path = os.path.join('cookies', f"linkedin_cookies_{session['username']}.pkl")
+    cookie_path = os.path.join('cookies', f"linkedin_cookies_{session['username']}.json")
     if not os.path.exists(cookie_path):
         return jsonify({'valid': False})
         
@@ -321,7 +321,7 @@ def connection_stats():
         return jsonify({'success': False, 'message': 'Not logged in'})
         
     try:
-        cookie_path = os.path.join('cookies', f"linkedin_cookies_{session['username']}.pkl")
+        cookie_path = os.path.join('cookies', f"linkedin_cookies_{session['username']}.json")
         if not os.path.exists(cookie_path):
             return jsonify({'success': False, 'message': 'No valid session found'})
             
@@ -330,8 +330,8 @@ def connection_stats():
         try:
             # Load cookies
             driver.get('https://www.linkedin.com')
-            with open(cookie_path, 'rb') as file:
-                cookies = pickle.load(file)
+            with open(cookie_path, 'r') as file:
+                cookies = json.load(file)
                 for cookie in cookies:
                     driver.add_cookie(cookie)
             
@@ -419,7 +419,7 @@ def delete_local_data():
         errors = []
         if os.path.exists(cookies_dir):
             for filename in os.listdir(cookies_dir):
-                if not filename.endswith('.pkl'):
+                if not filename.endswith('.json'):
                     continue
                 file_path = os.path.join(cookies_dir, filename)
                 try:

--- a/scripts/accept_connections.py
+++ b/scripts/accept_connections.py
@@ -6,7 +6,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, ElementClickInterceptedException
 import time
 import logging
-import pickle
+import json
 import sys
 
 def accept_connections():
@@ -26,8 +26,8 @@ def accept_connections():
         # Load cookies from file
         try:
             driver.get('https://www.linkedin.com')
-            with open('linkedin_cookies.pkl', 'rb') as file:
-                cookies = pickle.load(file)
+            with open('linkedin_cookies.json', 'r') as file:
+                cookies = json.load(file)
                 for cookie in cookies:
                     driver.add_cookie(cookie)
             logging.info("Cookies loaded successfully")

--- a/scripts/linkedin_login.py
+++ b/scripts/linkedin_login.py
@@ -7,7 +7,7 @@ from selenium.common.exceptions import TimeoutException, NoSuchElementException
 from flask import Flask, render_template, request, jsonify, session, redirect, url_for
 import time
 import logging
-import pickle
+import json
 import os
 
 # Configure logging
@@ -252,11 +252,11 @@ def submit_otp():
                 
             cookie_path = os.path.join(
                 cookie_dir, 
-                f"linkedin_cookies_{session['username']}.pkl"
+                f"linkedin_cookies_{session['username']}.json"
             )
             
-            with open(cookie_path, 'wb') as file:
-                pickle.dump(cookies, file)
+            with open(cookie_path, 'w') as file:
+                json.dump(cookies, file)
                 
             return jsonify({'success': True})
             


### PR DESCRIPTION
## Pull Request Summary
Security: Replace unsafe `pickle`-based cookie serialization with JSON to eliminate a potential remote code execution (RCE) vulnerability.  

This update addresses an insecure deserialization issue found in **app.py (lines 122 and 334)** where cookie data was loaded using `pickle.load()`. Since `pickle` can execute arbitrary code during deserialization, it poses a security risk if the file is tampered with.

This PR replaces pickle-based storage with JSON, a safe serialization format that cannot execute code.

Fixes #1 

---

## Changes Introduced

- Replace `pickle.load()` / `pickle.dump()` with `json.load()` / `json.dump()` in `app.py` and related scripts  
- Change cookie storage file extension from `.pkl` to `.json`  
- Update file open modes from binary (`rb`, `wb`) to text mode (`r`, `w`)  
- Ensure cookie dictionaries are properly serialized to JSON  

---

## Security Impact

Using Python's `pickle` module for loading stored cookies can allow **arbitrary code execution** if the serialized file is modified or replaced by a malicious actor.

Switching to JSON removes this risk because JSON only stores data and cannot execute code during deserialization.

This change mitigates the **OWASP insecure deserialization vulnerability**.

---

## Screenshots / Demo

N/A — backend security improvement with no UI changes.

| Before | After |
|:------:|:-----:|
| N/A | N/A |

---

## Checklist

- [x] Code follows project conventions and best practices  
- [x] Security risk removed (unsafe pickle deserialization)  
- [x] No functional regression in cookie handling  
- [x] Documentation updated where applicable  
- [x] No UI impact  

---

## Additional Notes

- Selenium's `driver.get_cookies()` returns dictionaries, which are fully compatible with JSON serialization.
- Any previously saved `.pkl` cookie files will need to be removed so the application can generate new `.json` cookie files on the next login.